### PR TITLE
Replace to simpleIcon CDN with theme specific color

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-[<img align="left" alt="yegor256 | Gmail" width="22px" src="https://cdn.jsdelivr.net/npm/simple-icons@v3/icons/gmail.svg" />](mailto:yegor256@gmail.com)
-[<img align="left" alt="yegor256 | LinkedIn" width="22px" src="https://cdn.jsdelivr.net/npm/simple-icons@v3/icons/linkedin.svg" />](https://www.linkedin.com/in/yegor256)
-[<img align="left" alt="yegor256 | Twitter" width="22px" src="https://cdn.jsdelivr.net/npm/simple-icons@v3/icons/twitter.svg" />](https://twitter.com/intent/follow?screen_name=yegor256)
-[<img align="left" alt="yegor256 | Telegram" width="22px" src="https://cdn.jsdelivr.net/npm/simple-icons@v3/icons/telegram.svg" />](https://t.me/yegor256news)
-[<img align="left" alt="yegor256 | Instagram" width="22px" src="https://cdn.jsdelivr.net/npm/simple-icons@v3/icons/instagram.svg" />](https://instagram.com/yegor256)
+[<img align="left" alt="yegor256 | Gmail" width="22px" src="https://cdn.simpleicons.org/gmail/black/white" />](mailto:yegor256@gmail.com)
+[<img align="left" alt="yegor256 | LinkedIn" width="22px" src="https://cdn.simpleicons.org/linkedin/black/white" />](https://www.linkedin.com/in/yegor256)
+[<img align="left" alt="yegor256 | Twitter" width="22px" src="https://cdn.simpleicons.org/twitter/black/white" />](https://twitter.com/intent/follow?screen_name=yegor256)
+[<img align="left" alt="yegor256 | Telegram" width="22px" src="https://cdn.simpleicons.org/telegram/black/white" />](https://t.me/yegor256news)
+[<img align="left" alt="yegor256 | Instagram" width="22px" src="https://cdn.simpleicons.org/instagram/black/white" />](https://instagram.com/yegor256)
 <br/>
 
 You may want to:


### PR DESCRIPTION
I replaced the URL from cdn.jsdelivr.net with cdn.simpleicons.org. The simpleicons repository supports color for both dark and light themes.

Official usage guide: https://github.com/simple-icons/simple-icons?tab=readme-ov-file#cdn-with-colors

fix #6 